### PR TITLE
Added alt text to image

### DIFF
--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,1 +1,1 @@
-<img src="/images/vonagelogo-secondary-black.png"></img>
+<img src="/images/vonagelogo-secondary-black.png" alt="Vonage Logo"></img>


### PR DESCRIPTION
The alt attribute specifies an alternate text to the image if it cannot be displayed.